### PR TITLE
Updates to workbench

### DIFF
--- a/src/blocks/workbench/filter_menu.rs
+++ b/src/blocks/workbench/filter_menu.rs
@@ -80,7 +80,7 @@ pub fn FilterMenu() -> impl IntoView {
     let element_checks = RwSignal::new(HashMap::new());
 
     element_checks.update_untracked(|map| {
-        for elem in element_counts.read().keys() {
+        for elem in element_counts.read_untracked().keys() {
             map.insert(*elem, true);
         }
     });


### PR DESCRIPTION
Persistent menu values when opening and closing menus closes #82.

Filter menu elements are sorted lexicographically in each category closes #170. 