### PR TITLE
Characteristics & error propagation

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -1,4 +1,10 @@
+use std::fmt::{Display, Formatter};
+
 use grapher::prelude::{ElementType, OwlEdge, OwlType, RdfEdge, RdfType};
+use oxrdf::{BlankNodeIdParseError, IriParseError};
+use vowlr_parser::errors::VOWLRStoreError;
+
+use crate::serializers::Triple;
 
 pub mod serializers;
 pub mod store;
@@ -23,3 +29,80 @@ pub const PROPERTY_EDGE_TYPES: [ElementType; 7] = [
     ElementType::Owl(OwlType::Edge(OwlEdge::InverseOf)),
     ElementType::Rdf(RdfType::Edge(RdfEdge::RdfProperty)),
 ];
+
+pub trait SerializationErrorExt {
+    fn triple(&self) -> Option<&Triple>;
+}
+
+macro_rules! ser_err {
+    ($variant:ident($triple:expr, $msg:expr)) => {
+        $crate::SerializationErrorKind::$variant(($triple).map(Box::new), $msg)
+    };
+}
+pub(crate) use ser_err;
+
+#[derive(Debug)]
+pub enum SerializationErrorKind {
+    MissingObject(Option<Box<Triple>>, String),
+    MissingSubject(Option<Box<Triple>>, String),
+    SerializationFailed(Option<Box<Triple>>, String),
+    IriParseError(Option<Box<Triple>>, Box<IriParseError>),
+    BlankNodeParseError(Option<Box<Triple>>, Box<BlankNodeIdParseError>),
+}
+impl SerializationErrorExt for SerializationErrorKind {
+    fn triple(&self) -> Option<&Triple> {
+        match &self {
+            SerializationErrorKind::MissingObject(triple, _)
+            | SerializationErrorKind::MissingSubject(triple, _)
+            | SerializationErrorKind::SerializationFailed(triple, _)
+            | SerializationErrorKind::IriParseError(triple, _)
+            | SerializationErrorKind::BlankNodeParseError(triple, _) => {
+                triple.as_ref().map(|t| &**t)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SerializationError {
+    inner: SerializationErrorKind,
+}
+impl Display for SerializationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SerializationError: {:?}", self.inner)
+    }
+}
+
+impl SerializationErrorExt for SerializationError {
+    fn triple(&self) -> Option<&Triple> {
+        self.inner.triple()
+    }
+}
+
+impl From<SerializationErrorKind> for SerializationError {
+    fn from(error: SerializationErrorKind) -> Self {
+        SerializationError { inner: error }
+    }
+}
+
+impl From<IriParseError> for SerializationError {
+    fn from(error: IriParseError) -> Self {
+        SerializationError {
+            inner: SerializationErrorKind::IriParseError(None, Box::new(error)),
+        }
+    }
+}
+
+impl From<SerializationError> for VOWLRStoreError {
+    fn from(error: SerializationError) -> Self {
+        VOWLRStoreError::from(error.to_string())
+    }
+}
+
+impl From<BlankNodeIdParseError> for SerializationError {
+    fn from(error: BlankNodeIdParseError) -> Self {
+        SerializationError {
+            inner: SerializationErrorKind::BlankNodeParseError(None, Box::new(error)),
+        }
+    }
+}

--- a/crates/database/src/serializers.rs
+++ b/crates/database/src/serializers.rs
@@ -188,17 +188,17 @@ pub struct SerializationDataBuffer {
     ///
     /// - Key = The property IRI.
     /// - Value = The edges of the property.
-    property_edge_map: HashMap<String, Edge>,
+    property_edge_map: HashMap<Term, Edge>,
     /// Stores the domains of a property.
     ///
     /// - Key = The property IRI.
     /// - Value = The domains of the property.
-    property_domain_map: HashMap<String, HashSet<String>>,
+    property_domain_map: HashMap<Term, HashSet<Term>>,
     /// Stores the ranges of a property.
     ///
     /// - Key = The property IRI.
     /// - Value = The ranges of the property.
-    property_range_map: HashMap<String, HashSet<String>>,
+    property_range_map: HashMap<Term, HashSet<Term>>,
     /// Stores labels of subject/object.
     ///
     /// - Key = The IRI the label belongs to.
@@ -258,16 +258,16 @@ impl SerializationDataBuffer {
     }
 }
 impl SerializationDataBuffer {
-    pub fn add_property_edge(&mut self, property_iri: String, edge: Edge) {
+    pub fn add_property_edge(&mut self, property_iri: Term, edge: Edge) {
         self.property_edge_map.insert(property_iri, edge);
     }
-    pub fn add_property_domain(&mut self, property_iri: String, domain: String) {
+    pub fn add_property_domain(&mut self, property_iri: Term, domain: Term) {
         self.property_domain_map
             .entry(property_iri)
             .or_default()
             .insert(domain);
     }
-    pub fn add_property_range(&mut self, property_iri: String, range: String) {
+    pub fn add_property_range(&mut self, property_iri: Term, range: Term) {
         self.property_range_map
             .entry(property_iri)
             .or_default()

--- a/crates/sparql_queries/src/lib.rs
+++ b/crates/sparql_queries/src/lib.rs
@@ -9,7 +9,7 @@ mod snippets;
 
 /// Exports all the core types of the library.
 pub mod prelude {
-    use grapher::prelude::{OwlEdge, OwlNode, RdfEdge, RdfsEdge, RdfsNode};
+    use grapher::prelude::{Characteristic, OwlEdge, OwlNode, RdfEdge, RdfsEdge, RdfsNode};
     use std::sync::LazyLock;
 
     use crate::assembly::DEFAULT_PREFIXES;
@@ -38,6 +38,7 @@ pub mod prelude {
             snippets_from_enum::<RdfEdge>(),
             snippets_from_enum::<RdfsNode>(),
             snippets_from_enum::<RdfsEdge>(),
+            snippets_from_enum::<Characteristic>(),
             GENERAL_SNIPPETS.into(),
         ]
         .concat();

--- a/crates/sparql_queries/src/snippets.rs
+++ b/crates/sparql_queries/src/snippets.rs
@@ -1,3 +1,4 @@
+pub mod characteristic;
 pub mod element_type;
 pub mod general;
 pub mod generic;

--- a/crates/sparql_queries/src/snippets/characteristic.rs
+++ b/crates/sparql_queries/src/snippets/characteristic.rs
@@ -1,0 +1,58 @@
+use grapher::prelude::Characteristic;
+
+use crate::snippets::SparqlSnippet;
+
+impl SparqlSnippet for Characteristic {
+    fn snippet(self) -> &'static str {
+        match self {
+            Characteristic::Transitive => {
+                r#"{
+                ?id a owl:TransitiveProperty
+                BIND(owl:TransitiveProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::FunctionalProperty => {
+                r#"{
+                ?id a owl:FunctionalProperty
+                BIND(owl:FunctionalProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::InverseFunctionalProperty => {
+                r#"{
+                ?id a owl:InverseFunctionalProperty
+                BIND(owl:InverseFunctionalProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::ReflexiveProperty => {
+                r#"{
+                ?id a owl:ReflexiveProperty
+                BIND(owl:ReflexiveProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::IrreflexiveProperty => {
+                r#"{
+                ?id a owl:IrreflexiveProperty
+                BIND(owl:IrreflexiveProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::SymmetricProperty => {
+                r#"{
+                ?id a owl:SymmetricProperty
+                BIND(owl:SymmetricProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::AsymmetricProperty => {
+                r#"{
+                ?id a owl:AsymmetricProperty
+                BIND(owl:AsymmetricProperty AS ?nodeType)
+            }"#
+            }
+            Characteristic::HasKey => {
+                r#"{
+                ?id a owl:hasKey
+                BIND(owl:hasKey AS ?nodeType)
+            }"#
+            }
+        }
+    }
+}


### PR DESCRIPTION
Duplicate of #173, however with clean commit. 

Resolves the reviews by: propagating errors during serialization, adding to failed_buffer after write_triple.

as per original pr:

After #168, implementing characteristics are pretty trivial. Just checks whether we know the property, and if it has an edge, if so insert the characteristic.

closes #113, closes #114, closes #115, closes #116, closes #117, closes #118, closes #119