### PR TITLE
Fix typo on TransitiveProperty

### DIFF
--- a/crates/database/src/serializers/frontend.rs
+++ b/crates/database/src/serializers/frontend.rs
@@ -970,7 +970,7 @@ impl GraphDisplayDataSolutionSerializer {
                     owl::TRANSITIVE_PROPERTY => self.insert_characteristic(
                         data_buffer,
                         triple,
-                        Characteristic::Transitive.to_string(),
+                        Characteristic::TransitiveProperty.to_string(),
                     ),
                     owl::UNION_OF => {
                         let edge =

--- a/crates/sparql_queries/src/snippets/characteristic.rs
+++ b/crates/sparql_queries/src/snippets/characteristic.rs
@@ -5,7 +5,7 @@ use crate::snippets::SparqlSnippet;
 impl SparqlSnippet for Characteristic {
     fn snippet(self) -> &'static str {
         match self {
-            Characteristic::Transitive => {
+            Characteristic::TransitiveProperty => {
                 r#"{
                 ?id a owl:TransitiveProperty
                 BIND(owl:TransitiveProperty AS ?nodeType)


### PR DESCRIPTION
Fixes issue caused by merging [Fix typo in transitive characteristic](https://github.com/WebVOWL/WasmGrapher/pull/64)