### PR TITLE
Settings adjust

### DIFF
--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -1,5 +1,4 @@
 use super::WorkbenchMenuItems;
-// use crate::components::tooltip::{ToolTip, ToolTipPosition};
 use crate::components::user_input::range_select::Slider;
 use crate::errors::{ClientErrorKind, ErrorLogContext};
 use grapher::prelude::*;

--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -51,8 +51,7 @@ pub fn SimulatorSettings() -> impl IntoView {
                     ></Slider>
                 {// </ToolTip<f64>>
 
-                // <ToolTip<f64> content=spring_stiffness position=ToolTipPosition::Top>
-                   }   <Slider
+ <Slider
                         label="Edge Stiffness"
                         value=spring_stiffness
                         min="50.0"

--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -42,8 +42,7 @@ pub fn SimulatorSettings() -> impl IntoView {
         <fieldset>
             <legend>"Graph Simulation"</legend>
             <div class="flex flex-col content-around m-4 size-fit">
-                {// <ToolTip<f64> content=repel_force position=ToolTipPosition::Top>
-                   }   <Slider
+  <Slider
                         label="Node Distance"
                         value=repel_force
                         min=(-10e8).to_string()

--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -58,8 +58,6 @@ pub fn SimulatorSettings() -> impl IntoView {
                         max="200.0"
                         step="10.0"
                     ></Slider>
-              {  // </ToolTip<f64>>
-              }
                 <Slider
                     label="Edge Length"
                     value=spring_neutral_length

--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -47,9 +47,9 @@ pub fn SimulatorSettings() -> impl IntoView {
                     <Slider
                         label="Node Distance"
                         value=repel_force
-                        min=10e6.to_string()
-                        max=10e8.to_string()
-                        step=10e3.to_string()
+                        min=(-10e8).to_string()
+                        max=(-10e6).to_string()
+                        step=(-10e3).to_string()
                     ></Slider>
                 </ToolTip<f64>>
 
@@ -57,9 +57,9 @@ pub fn SimulatorSettings() -> impl IntoView {
                     <Slider
                         label="Edge Stiffness"
                         value=spring_stiffness
-                        min="100.0"
-                        max="600.0"
-                        step="100.0"
+                        min="50.0"
+                        max="200.0"
+                        step="10.0"
                     ></Slider>
                 </ToolTip<f64>>
 
@@ -67,7 +67,7 @@ pub fn SimulatorSettings() -> impl IntoView {
                     label="Edge Length"
                     value=spring_neutral_length
                     min="20.0"
-                    max="120.0"
+                    max="200.0"
                     step="10.0"
                 ></Slider>
 

--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -1,5 +1,5 @@
 use super::WorkbenchMenuItems;
-use crate::components::tooltip::{ToolTip, ToolTipPosition};
+// use crate::components::tooltip::{ToolTip, ToolTipPosition};
 use crate::components::user_input::range_select::Slider;
 use crate::errors::{ClientErrorKind, ErrorLogContext};
 use grapher::prelude::*;
@@ -43,26 +43,26 @@ pub fn SimulatorSettings() -> impl IntoView {
         <fieldset>
             <legend>"Graph Simulation"</legend>
             <div class="flex flex-col content-around m-4 size-fit">
-                <ToolTip<f64> content=repel_force position=ToolTipPosition::Top>
-                    <Slider
+                {// <ToolTip<f64> content=repel_force position=ToolTipPosition::Top>
+                   }   <Slider
                         label="Node Distance"
                         value=repel_force
                         min=(-10e8).to_string()
                         max=(-10e6).to_string()
                         step=(-10e3).to_string()
                     ></Slider>
-                </ToolTip<f64>>
+                {// </ToolTip<f64>>
 
-                <ToolTip<f64> content=spring_stiffness position=ToolTipPosition::Top>
-                    <Slider
+                // <ToolTip<f64> content=spring_stiffness position=ToolTipPosition::Top>
+                   }   <Slider
                         label="Edge Stiffness"
                         value=spring_stiffness
                         min="50.0"
                         max="200.0"
                         step="10.0"
                     ></Slider>
-                </ToolTip<f64>>
-
+              {  // </ToolTip<f64>>
+              }
                 <Slider
                     label="Edge Length"
                     value=spring_neutral_length

--- a/src/blocks/workbench/options_menu.rs
+++ b/src/blocks/workbench/options_menu.rs
@@ -42,22 +42,21 @@ pub fn SimulatorSettings() -> impl IntoView {
         <fieldset>
             <legend>"Graph Simulation"</legend>
             <div class="flex flex-col content-around m-4 size-fit">
-  <Slider
-                        label="Node Distance"
-                        value=repel_force
-                        min=(-10e8).to_string()
-                        max=(-10e6).to_string()
-                        step=(-10e3).to_string()
-                    ></Slider>
-                {// </ToolTip<f64>>
+                <Slider
+                    label="Node Distance"
+                    value=repel_force
+                    min=(-10e8).to_string()
+                    max=(-10e6).to_string()
+                    step=(-10e3).to_string()
+                ></Slider>
 
- <Slider
-                        label="Edge Stiffness"
-                        value=spring_stiffness
-                        min="50.0"
-                        max="200.0"
-                        step="10.0"
-                    ></Slider>
+                <Slider
+                    label="Edge Stiffness"
+                    value=spring_stiffness
+                    min="50.0"
+                    max="200.0"
+                    step="10.0"
+                ></Slider>
                 <Slider
                     label="Edge Length"
                     value=spring_neutral_length


### PR DESCRIPTION
- Adjust values to sensible defaults and prevent weird simulation behavior with extreme values.
- Disable broken tooltip.