### PR TITLE
Metadata formatting

### DIFF
--- a/crates/serializer/src/datastructures/graph_metadata_buffer.rs
+++ b/crates/serializer/src/datastructures/graph_metadata_buffer.rs
@@ -81,7 +81,12 @@ impl GraphMetadataBuffer {
             let mut out = HashMap::new();
             for (lang_tag, content) in tagged_metadata {
                 let k = fmt_langtag(lang_tag.clone());
-                let v = fmt_translated_metadata_content(content, &self.term_index, term_cache)?;
+                let v = fmt_translated_metadata_content(
+                    content,
+                    metadata_term_id,
+                    &self.term_index,
+                    term_cache,
+                )?;
                 out.insert(k, v);
             }
 

--- a/crates/serializer/src/datastructures/index.rs
+++ b/crates/serializer/src/datastructures/index.rs
@@ -8,6 +8,7 @@ use oxrdf::{Term, TermRef};
 use crate::{
     datastructures::{ArcEdge, ArcTerm, ArcTriple},
     errors::{SerializationError, SerializationErrorKind},
+    serializer_util::trim_terms,
 };
 
 #[derive(Debug, Default)]
@@ -193,6 +194,6 @@ impl TermIndex {
     /// Use only in infallible contexts.
     pub fn display_term(&self, term_id: usize) -> String {
         self.get(term_id)
-            .map_or_else(|e| e.to_string(), |term| term.to_string())
+            .map_or_else(|e| e.to_string(), |term| trim_terms(&term.to_string()))
     }
 }

--- a/crates/serializer/src/datastructures/serialization_data_buffer.rs
+++ b/crates/serializer/src/datastructures/serialization_data_buffer.rs
@@ -514,6 +514,7 @@ impl SerializationDataBuffer {
                                     .or_insert_with(|| {
                                         match fmt_translated_metadata_content(
                                             &content,
+                                            metadata_term_id,
                                             &self.term_index,
                                             term_cache,
                                         ) {

--- a/crates/serializer/src/serializer_util.rs
+++ b/crates/serializer/src/serializer_util.rs
@@ -20,7 +20,7 @@ use vowlgrapher_util::prelude::ErrorRecord;
 
 use crate::{
     datastructures::{
-        ArcTerm, DisplayCase, LanguageTag, MetadataContent, index::TermIndex,
+        ArcTerm, DisplayCase, LanguageTag, MetadataContent, MetadataTermID, index::TermIndex,
         serialization_data_buffer::SerializationDataBuffer,
     },
     errors::{SerializationError, SerializationErrorKind},
@@ -235,6 +235,46 @@ pub fn trim_tag_circumfix(input: &str) -> String {
         .to_string()
 }
 
+/// Removes wrapping double quotes from metadata values.
+pub fn trim_wrapping_quotes(input: &str) -> String {
+    input
+        .trim_start_matches('"')
+        .trim_end_matches('"')
+        .to_string()
+}
+
+/// Removes language tags from metadata values.
+pub fn trim_lang_tag(input: &str) -> String {
+    input
+        .rfind('@')
+        .map_or_else(|| input.to_string(), |idx| input[..idx].to_string())
+}
+
+/// Removes datatype tags from metadata values.
+pub fn trim_datatype(input: &str) -> String {
+    input
+        .rfind("^^")
+        .map_or_else(|| input.to_string(), |idx| input[..idx].to_string())
+}
+
+/// Performs all trimming steps for metadata values.
+pub fn trim_terms(input: &str) -> String {
+    let trimmed = trim_datatype(input);
+    let trimmed = trim_lang_tag(&trimmed);
+    let trimmed = trim_tag_circumfix(&trimmed);
+    trim_wrapping_quotes(&trimmed)
+}
+
+/// Determines whether the raw metadata value should be preserved for a given metadata term.
+fn should_preserve_raw_metadata_value(
+    metadata_term_id: MetadataTermID,
+    term_index: &TermIndex,
+) -> bool {
+    term_index
+        .get(metadata_term_id)
+        .is_ok_and(|term| matches!(term.as_ref().as_ref(), TermRef::NamedNode(named_node_ref) if named_node_ref == rdfs::IS_DEFINED_BY || named_node_ref == rdfs::SEE_ALSO))
+}
+
 /// Generate a new IRI based on a current one.
 pub fn synthetic_iri(base: &ArcTerm, suffix: &str) -> String {
     let clean = trim_tag_circumfix(&base.to_string());
@@ -300,14 +340,21 @@ pub fn get_term_string(
 /// Translates the term ids of metadata content into term strings.
 pub fn fmt_translated_metadata_content(
     content: &MetadataContent,
+    metadata_term_id: MetadataTermID,
     term_index: &TermIndex,
     term_cache: &mut HashMap<ArcTerm, Arc<String>>,
 ) -> Result<Vec<String>, SerializationError> {
     let mut out = Vec::with_capacity(content.len());
     for content_term_id in content {
         let term = term_index.get(*content_term_id)?;
-        let term_str = get_term_string(&term, DisplayCase::Original, term_cache);
-        out.push(term_str.to_string());
+        let cleaned_str = if should_preserve_raw_metadata_value(metadata_term_id, term_index) {
+            trim_terms(&term.to_string())
+        } else {
+            let term_str = get_term_string(&term, DisplayCase::Original, term_cache);
+            trim_terms(&term_str)
+        };
+
+        out.push(cleaned_str);
     }
     Ok(out)
 }

--- a/crates/serializer/src/serializer_util.rs
+++ b/crates/serializer/src/serializer_util.rs
@@ -270,9 +270,12 @@ fn should_preserve_raw_metadata_value(
     metadata_term_id: MetadataTermID,
     term_index: &TermIndex,
 ) -> bool {
-    term_index
-        .get(metadata_term_id)
-        .is_ok_and(|term| matches!(term.as_ref().as_ref(), TermRef::NamedNode(named_node_ref) if named_node_ref == rdfs::IS_DEFINED_BY || named_node_ref == rdfs::SEE_ALSO))
+    term_index.get(metadata_term_id).is_ok_and(|term| {
+        matches!(
+            (*term).as_ref(),
+            TermRef::NamedNode(rdfs::IS_DEFINED_BY | rdfs::SEE_ALSO)
+        )
+    })
 }
 
 /// Generate a new IRI based on a current one.

--- a/src/blocks/right_sidebar.rs
+++ b/src/blocks/right_sidebar.rs
@@ -65,6 +65,21 @@ pub fn metadata_value(
     })
 }
 
+/// Displays a value as a clickable link if it's a URL, otherwise as plain text.
+pub fn display_url_or_text(value: String) -> AnyView {
+    if value.starts_with("http://") || value.starts_with("https://") {
+        let url = value.clone();
+        view! {
+            <a href=url target="_blank" class="text-blue-600 hover:underline">
+                {value}
+            </a>
+        }
+        .into_any()
+    } else {
+        view! { <span>{value}</span> }.into_any()
+    }
+}
+
 #[component]
 pub fn RightSidebar() -> impl IntoView {
     let selected_language_tag = LanguageSelection::default();

--- a/src/blocks/right_sidebar/ontology_header.rs
+++ b/src/blocks/right_sidebar/ontology_header.rs
@@ -2,7 +2,8 @@ use std::{collections::HashMap, iter::once};
 
 use crate::{
     blocks::right_sidebar::{
-        LanguageSelection, default_metadata_value_signal, metadata_value_signal, display_url_or_text,
+        LanguageSelection, default_metadata_value_signal, display_url_or_text,
+        metadata_value_signal,
     },
     components::{accordion::Accordion, user_input::internal_sparql::GraphDataContext},
 };

--- a/src/blocks/right_sidebar/ontology_header.rs
+++ b/src/blocks/right_sidebar/ontology_header.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, iter::once};
 
 use crate::{
     blocks::right_sidebar::{
-        LanguageSelection, default_metadata_value_signal, metadata_value_signal,
+        LanguageSelection, default_metadata_value_signal, metadata_value_signal, display_url_or_text,
     },
     components::{accordion::Accordion, user_input::internal_sparql::GraphDataContext},
 };
@@ -26,15 +26,17 @@ pub fn Title(
 #[component]
 pub fn DocumentBase(#[prop(into)] base: Signal<String>) -> impl IntoView {
     view! {
-        <p class="flex gap-2 justify-center items-center py-2 my-2 text-sm text-gray-500">
-            <a
-                href=move || base.get()
-                target="_blank"
-                class="text-blue-600 hover:underline"
-            >
-                {move || base.get()}
-            </a>
-        </p>
+        <div class="py-2 my-2 text-sm text-gray-500">
+            <p class="text-center">
+                <a
+                    href=move || base.get()
+                    target="_blank"
+                    class="text-blue-600 break-words hover:underline"
+                >
+                    {move || base.get()}
+                </a>
+            </p>
+        </div>
     }
 }
 
@@ -46,17 +48,44 @@ pub fn Version(
     #[prop(into)] backward_compatible_with: Signal<Option<String>>,
 ) -> impl IntoView {
     view! {
-        <p class="flex gap-2 justify-center items-center py-2 my-2 text-sm text-gray-500">
-            "Version: "{move || version_iri.get().unwrap_or("None".to_string())}
-            <br /> "Prior Version: "
-            {move || prior_version.get().unwrap_or("None".to_string())} <br />
-            "Incompatible With: "
-            {move || incompatible_with.get().unwrap_or("None".to_string())}
-            <br /> "Backward Compatible With: "
-            {move || {
-                backward_compatible_with.get().unwrap_or("None".to_string())
-            }}
-        </p>
+        <div class="py-2 my-2 text-sm text-gray-500">
+            <p class="text-center break-words">
+                "Version: "
+                {move || {
+                    version_iri
+                        .get()
+                        .map(display_url_or_text)
+                        .unwrap_or_else(|| view! { <span>"None"</span> }.into_any())
+                }}
+            </p>
+            <p class="text-center break-words">
+                "Prior Version: "
+                {move || {
+                    prior_version
+                        .get()
+                        .map(display_url_or_text)
+                        .unwrap_or_else(|| view! { <span>"None"</span> }.into_any())
+                }}
+            </p>
+            <p class="text-center break-words">
+                "Incompatible With: "
+                {move || {
+                    incompatible_with
+                        .get()
+                        .map(display_url_or_text)
+                        .unwrap_or_else(|| view! { <span>"None"</span> }.into_any())
+                }}
+            </p>
+            <p class="text-center break-words">
+                "Backward Compatible With: "
+                {move || {
+                    backward_compatible_with
+                        .get()
+                        .map(display_url_or_text)
+                        .unwrap_or_else(|| view! { <span>"None"</span> }.into_any())
+                }}
+            </p>
+        </div>
     }
 }
 
@@ -72,10 +101,14 @@ pub fn Author(
     let shown_contributor =
         metadata_value_signal(contributors, default_contributor, selected_language.0);
     view! {
-        <p class="flex gap-2 justify-center items-center py-2 my-2 text-sm text-gray-500">
-            Author(s): {move || { shown_creator.get() }} <br />Contributor(s):
-            {move || shown_contributor.get()}
-        </p>
+        <div class="py-2 my-2 text-sm text-gray-500">
+            <p class="text-center break-words">
+                "Author(s): " {move || shown_creator.get().join(", ")}
+            </p>
+            <p class="text-center break-words">
+                "Contributor(s): " {move || shown_contributor.get().join(", ")}
+            </p>
+        </div>
     }
 }
 
@@ -118,8 +151,8 @@ pub fn Language(
     };
 
     view! {
-        <p class="flex gap-2 justify-center items-center py-2 my-2 text-sm text-gray-500">
-            "Languages:"
+        <div class="flex flex-col gap-2 items-center py-2 my-2 text-sm text-gray-500">
+            <p>"Languages:"</p>
             <select
                 class="py-1 px-2 text-sm text-gray-500 rounded-md border border-gray-300 focus:ring-2 focus:ring-blue-500 focus:outline-none w-[100px] h-[30px]"
                 prop:value=selected_language
@@ -130,7 +163,7 @@ pub fn Language(
             >
                 {shown_languages()}
             </select>
-        </p>
+        </div>
     }
 }
 
@@ -144,7 +177,7 @@ pub fn Description(
 
     view! {
         <Accordion title="Description">
-            <p>{move || shown_desc.get()}</p>
+            <p class="text-center break-words">{move || shown_desc.get()}</p>
         </Accordion>
     }
 }

--- a/src/blocks/right_sidebar/selection_details.rs
+++ b/src/blocks/right_sidebar/selection_details.rs
@@ -1,6 +1,6 @@
 use crate::{
     blocks::right_sidebar::{
-        LanguageSelection, default_metadata_value, metadata_value, display_url_or_text,
+        LanguageSelection, default_metadata_value, display_url_or_text, metadata_value,
     },
     components::{accordion::Accordion, user_input::internal_sparql::GraphDataContext},
     events::EventContext,

--- a/src/blocks/right_sidebar/selection_details.rs
+++ b/src/blocks/right_sidebar/selection_details.rs
@@ -44,7 +44,13 @@ pub fn SelectionDetails() -> impl IntoView {
                                             )
                                             .get();
                                         if should_be_link {
-                                            meta_val.into_iter().map(display_url_or_text).collect_view()
+                                            meta_val.into_iter().enumerate().map(|(i, v)| {
+                                                if i == 0 {
+                                                    display_url_or_text(v)
+                                                } else {
+                                                    view! { <div>{display_url_or_text(v)}</div> }.into_any()
+                                                }
+                                            }).collect_view()
                                         } else {
                                             meta_val
                                                 .into_iter()

--- a/src/blocks/right_sidebar/selection_details.rs
+++ b/src/blocks/right_sidebar/selection_details.rs
@@ -1,5 +1,7 @@
 use crate::{
-    blocks::right_sidebar::{LanguageSelection, default_metadata_value, metadata_value},
+    blocks::right_sidebar::{
+        LanguageSelection, default_metadata_value, metadata_value, display_url_or_text,
+    },
     components::{accordion::Accordion, user_input::internal_sparql::GraphDataContext},
     events::EventContext,
 };
@@ -28,14 +30,32 @@ pub fn SelectionDetails() -> impl IntoView {
                             let value = metadata_type_map.clone();
                             let default_value =
                                 Memo::new(move |_| default_metadata_value(value.clone()));
+                            let metadata_type_literal_lower = metadata_type_literal.to_lowercase();
+                            let should_be_link = metadata_type_literal_lower.contains("see also") 
+                                || metadata_type_literal_lower.contains("is defined by");
                             view! {
                                 <p>
                                     {move || { metadata_type_literal.as_ref().clone() }}": "
-                                    {move || metadata_value(
-                                        metadata_type_map.clone(),
-                                        default_value,
-                                        selected_language.0,
-                                    )}
+                                    {move || {
+                                        let meta_val = metadata_value(
+                                                metadata_type_map.clone(),
+                                                default_value,
+                                                selected_language.0,
+                                            )
+                                            .get();
+                                        if should_be_link {
+                                            meta_val.into_iter().map(display_url_or_text).collect_view()
+                                        } else {
+                                            meta_val
+                                                .into_iter()
+                                                .map(|value| {
+
+                                                    view! { <span>{value}</span> }
+                                                        .into_any()
+                                                })
+                                                .collect_view()
+                                        }
+                                    }}
                                 </p>
                             }
                         })


### PR DESCRIPTION
Fixes formatting for metadata

- Removes quotation marks
- Removes "@en" or other languages
- Removes datatypes (^^)
- Displays links where applicable (Version, Prior Version, See also, Is Defined By, etc.)
- Fixes that make the right sidebar look clean